### PR TITLE
Update for Django 4.2

### DIFF
--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -8,7 +8,7 @@ from importlib import import_module
 import six
 from django.core.cache import caches
 from django.core.files.base import ContentFile
-from django.utils.encoding import force_text, smart_bytes
+from django.utils.encoding import force_str, smart_bytes
 from django.utils.functional import SimpleLazyObject
 
 from compressor.conf import settings
@@ -26,11 +26,11 @@ def get_hexdigest(plaintext, length=None):
 
 
 def simple_cachekey(key):
-    return 'django_compressor.%s' % force_text(key)
+    return 'django_compressor.%s' % force_str(key)
 
 
 def socket_cachekey(key):
-    return 'django_compressor.%s.%s' % (socket.gethostname(), force_text(key))
+    return 'django_compressor.%s.%s' % (socket.gethostname(), force_str(key))
 
 
 def get_cachekey(*args, **kwargs):

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -21,7 +21,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.temp import NamedTemporaryFile
 
 import six
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from compressor.cache import cache, get_precompiler_cachekey
 
@@ -217,7 +217,7 @@ class CompilerFilter(FilterBase):
                 self.infile.close()
             if self.outfile is not None:
                 self.outfile.close()
-        return smart_text(filtered)
+        return smart_str(filtered)
 
 
 class CachedCompilerFilter(CompilerFilter):
@@ -231,7 +231,7 @@ class CachedCompilerFilter(CompilerFilter):
             key = self.get_cache_key()
             data = cache.get(key)
             if data is not None:
-                return smart_text(data)
+                return smart_str(data)
             filtered = super(CachedCompilerFilter, self).input(**kwargs)
             cache.set(key, filtered, settings.COMPRESS_REBUILD_TIMEOUT)
             return filtered

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -12,7 +12,7 @@ import six
 from django.core.management.base import BaseCommand, CommandError
 import django.template
 from django.template import Context
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.template.loader import get_template  # noqa Leave this in to preload template locations
 from django.template import engines
 
@@ -112,7 +112,7 @@ class Command(BaseCommand):
                         'get_template_sources', None)
                     if get_template_sources is None:
                         get_template_sources = loader.get_template_sources
-                    paths.update(smart_text(origin) for origin in get_template_sources(''))
+                    paths.update(smart_str(origin) for origin in get_template_sources(''))
                 except (ImportError, AttributeError, TypeError):
                     # Yeah, this didn't work out so well, let's move on
                     pass
@@ -174,7 +174,7 @@ class Command(BaseCommand):
                 continue
             except TemplateSyntaxError as e:  # broken template -> ignore
                 if verbosity >= 1:
-                    log.write("Invalid template %s: %s\n" % (template_name, smart_text(e)))
+                    log.write("Invalid template %s: %s\n" % (template_name, smart_str(e)))
                 continue
             except TemplateDoesNotExist:  # non existent template -> ignore
                 if verbosity >= 1:
@@ -202,7 +202,7 @@ class Command(BaseCommand):
                     # Could be an error in some base template
                     if verbosity >= 1:
                         log.write("Error parsing template %s: %s\n" %
-                                  (template.template_name, smart_text(e)))
+                                  (template.template_name, smart_str(e)))
                     continue
 
                 if nodes:
@@ -232,7 +232,7 @@ class Command(BaseCommand):
                             result = parser.render_node(template, context, node)
                         except Exception as e:
                             raise CommandError("An error occurred during rendering %s: "
-                                               "%s" % (template.template_name, smart_text(e)))
+                                               "%s" % (template.template_name, smart_str(e)))
                         result = result.replace(
                             settings.COMPRESS_URL, settings.COMPRESS_URL_PLACEHOLDER
                         )
@@ -304,4 +304,4 @@ class Command(BaseCommand):
         write_offline_manifest(final_offline_manifest)
         return final_block_count, final_results
 
-Command.requires_system_checks = False
+Command.requires_system_checks = []

--- a/compressor/parser/beautifulsoup.py
+++ b/compressor/parser/beautifulsoup.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from compressor.parser import ParserBase
 
@@ -37,7 +37,7 @@ class BeautifulSoupParser(ParserBase):
         return elem.name
 
     def elem_str(self, elem):
-        elem_as_string = smart_text(elem)
+        elem_as_string = smart_str(elem)
         if elem.name == 'link':
             # This makes testcases happy
             elem_as_string = elem_as_string.replace('/>', '>')

--- a/compressor/parser/default_htmlparser.py
+++ b/compressor/parser/default_htmlparser.py
@@ -1,7 +1,7 @@
 import sys
 
 import six
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from compressor.exceptions import ParserError
 from compressor.parser import ParserBase
@@ -74,7 +74,7 @@ class DefaultHtmlParser(ParserBase, six.moves.html_parser.HTMLParser):
         return elem['attrs_dict']
 
     def elem_content(self, elem):
-        return smart_text(elem['text'])
+        return smart_str(elem['text'])
 
     def elem_str(self, elem):
         tag = {}

--- a/compressor/parser/html5lib.py
+++ b/compressor/parser/html5lib.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.utils.functional import cached_property
 
 from compressor.exceptions import ParserError
@@ -45,7 +45,7 @@ class Html5LibParser(ParserBase):
         return elem.attrib
 
     def elem_content(self, elem):
-        return smart_text(elem.text)
+        return smart_str(elem.text)
 
     def elem_name(self, elem):
         if '}' in elem.tag:
@@ -56,4 +56,4 @@ class Html5LibParser(ParserBase):
         # This method serializes HTML in a way that does not pass all tests.
         # However, this method is only called in tests anyway, so it doesn't
         # really matter.
-        return smart_text(self._serialize(elem))
+        return smart_str(self._serialize(elem))

--- a/compressor/parser/lxml.py
+++ b/compressor/parser/lxml.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import six
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.utils.functional import cached_property
 
 from compressor.exceptions import ParserError
@@ -67,10 +67,10 @@ class LxmlParser(ParserBase):
         return elem.attrib
 
     def elem_content(self, elem):
-        return smart_text(elem.text)
+        return smart_str(elem.text)
 
     def elem_name(self, elem):
         return elem.tag
 
     def elem_str(self, elem):
-        return smart_text(self.tostring(elem, method='html', encoding=six.text_type))
+        return smart_str(self.tostring(elem, method='html', encoding=six.text_type))

--- a/compressor/signals.py
+++ b/compressor/signals.py
@@ -1,4 +1,4 @@
 import django.dispatch
 
 
-post_compress = django.dispatch.Signal(providing_args=['type', 'mode', 'context'])
+post_compress = django.dispatch.Signal()

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -7,7 +7,7 @@ import sys
 import unittest
 
 import six
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -124,7 +124,7 @@ class PrecompilerTestCase(TestCase):
         command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)
         compiler = CachedCompilerFilter(command=command, **self.cached_precompiler_args)
         self.assertEqual("body { color:#990; }", compiler.input())
-        self.assertEqual(type(compiler.input()), type(smart_text("body { color:#990; }")))
+        self.assertEqual(type(compiler.input()), type(smart_str("body { color:#990; }")))
 
     def test_precompiler_not_cacheable(self):
         command = '%s %s -f {infile} -o {outfile}' % (sys.executable, self.test_precompiler)


### PR DESCRIPTION
# Compatibility fixes for Django 4.2

## Django 4.0.10
* [Django 4.0 deprecations](https://docs.djangoproject.com/en/5.0/internals/deprecation/#deprecation-removed-in-4-0):
* See the [Django 3.0 release notes](https://docs.djangoproject.com/en/5.0/releases/3.0/#deprecated-features-3-0) for more details on these changes.

- [x] **django.utils.encoding.force_text()** and **smart_text()** will be removed.  The aliases are  force_str() and smart_str().
- [x] **django.utils.http.urlquote()**, **urlquote_plus()**, **urlunquote()**, and **urlunquote_plus()** will be removed.
- [x] **django.utils.translation.ugettext()**, **ugettext_lazy()**, **ugettext_noop()**, **ungettext()**, and **ungettext_lazy()** will be removed.
- [x] **django.views.i18n.set_language()** will no longer set the user language in **request.session** (key **django.utils.translation.LANGUAGE_SESSION_KEY**). 
- [x] **alias=None** will be required in the signature of **django.db.models.Expression.get_group_by_cols()** subclasses.
- [x] **django.utils.text.unescape_entities()** will be removed.
- [x] **django.utils.http.is_safe_url()** will be removed.

* See the [Django 3.1 release notes](https://docs.djangoproject.com/en/5.0/releases/3.1/#deprecated-features-3-1) for more details on these changes.
- [x] **The PASSWORD_RESET_TIMEOUT_DAYS** setting will be removed.
- [x] The undocumented usage of the **isnull** lookup with non-boolean values as the right-hand side will no longer be allowed.
- [x] The **django.db.models.query_utils.InvalidQuery** exception class will be removed.
- [x] The **django-admin.py** entry point will be removed.
- [x] Support for the pre-Django 3.1 encoding format of cookies values used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] The **providing_args** argument for **django.dispatch.Signal** will be removed.
- [x] The **length** argument for **django.utils.crypto.get_random_string()** will be required.
- [x] The model **NullBooleanField** will be removed. A stub field will remain for compatibility with historical migrations. 
- [x] The model **django.contrib.postgres.fields.JSONField** will be removed. A stub field will remain for compatibility with historical migrations.
- [x] **django.contrib.postgres.forms.JSONField**, **django.contrib.postgres.fields.jsonb.KeyTransform**, and **django.contrib.postgres.fields.jsonb.KeyTextTransform** will be removed.
- [x] The **DEFAULT_HASHING_ALGORITHM** transitional setting will be removed.
- [x] Support for passing raw column aliases to **QuerySet.order_by()** will be removed.
- [x] **django.conf.urls.url()** will be removed.  It's an alias of **django.urls.re_path()**.
- [x] The **get_response** argument for **django.utils.deprecation.MiddlewareMixin.__init__()** will be required and won’t accept **None**.
- [x] The **list** message for **ModelMultipleChoiceField** will be removed.
- [x] The **HttpRequest.is_ajax()** method will be removed.
- [x] The **{% ifequal %}** and **{% ifnotequal %}** template tags will be removed.

### pre-Django 3.1 SHA-1
- [x] Support for the pre-Django 3.1 password reset tokens in the admin site (that use the SHA-1 hashing algorithm) will be removed.
- [x] Support for the pre-Django 3.1 encoding format of sessions will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.Signer** signatures (encoded with the SHA-1 algorithm) will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.dumps()** signatures (encoded with the SHA-1 algorithm) in **django.core.signing.loads()** will be removed.
- [x] Support for the pre-Django 3.1 user sessions (that use the SHA-1 algorithm) will be removed.

## Django 4.1.13
See the [Django 3.2 release notes](https://docs.djangoproject.com/en/5.0/releases/3.2/#deprecated-features-3-2) for more details on these changes.

- [x] Support for assigning objects which don’t support creating deep copies with **copy.deepcopy()** to class attributes in **TestCase.setUpTestData()** will be removed.
- [x] The **whitelist** argument and **domain_whitelist** attribute of **django.core.validators.EmailValidator** will be removed.
- [x] **TransactionTestCase.assertQuerysetEqual()** will no longer automatically call **repr()** on a queryset when compared to string values.
- [x] Support for the pre-Django 3.2 format of messages used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] **BaseCommand.requires_system_checks** won’t support boolean values. Use '__all__' instead of True, and [] (an empty list) instead of False.
- [x] **django.core.cache.backends.memcached.MemcachedCache** will be removed.
- [x] The **default_app_config** module variable will be removed. 
